### PR TITLE
Navbar fixture homepage

### DIFF
--- a/geomanagerweb/templates/base.html
+++ b/geomanagerweb/templates/base.html
@@ -116,7 +116,7 @@
 </head>
 
 <body class="{% block body_class %}{% endblock %}">
-    {% include "geomanager/navbar.html" %}
+    {% include "navbar.html" %}
     {% wagtailuserbar %}
 
     <div class="content-wrapper">
@@ -129,49 +129,51 @@
                 <!-- Logo and description section -->
                 <div class="column is-one-quarter">
                     <img src="{% static 'images/ICPAC_Logo_White.svg' %}" alt="ICPAC Logo" class="footer-logo" style="max-width:150px;margin-bottom:1rem;"> 
-                    <p class="footer-text">East Africa Hazards Watch</p>
+                    <p class="footer-text">East Africa Hazards Watch - Monitoring and forecasting platform for East Africa</p>
                 </div>
                 
                 <!-- SERVICES section -->
                 <div class="column is-one-quarter">
-                    <h4 class="footer-heading">SERVICES</h4>
+                    <h2 class="footer-heading is-size-5">SERVICES</h2>
                     <ul>
-                        <li><a href="https://www.icpac.net/agriculture-and-food-security/">Agriculture and Food Security</a></li>
-                        <li><a href="https://www.icpac.net/climate-forecasting/">Climate Forecasting and Early Warning</a></li>
-                        <li><a href="https://www.icpac.net/capacity-development/">Capacity Development</a></li>
-                        <li><a href="https://www.icpac.net/climate-change/">Climate Change</a></li>
-                        <li><a href="https://www.icpac.net/disaster-risk-management/">Disaster Risk Mangement</a></li>
-                        <li><a href="https://www.icpac.net/environmental-monitoring/">Environmental Monitoring</a></li>
-                        <li><a href="https://www.icpac.net/water-resources/">Water Resources</a></li>
+                        <li><a href="https://www.icpac.net/agriculture-and-food-security/" title="Agriculture and Food Security Services">Agriculture and Food Security</a></li>
+                        <li><a href="https://www.icpac.net/climate-forecasting/" title="Climate Forecasting and Early Warning Services">Climate Forecasting and Early Warning</a></li>
+                        <li><a href="https://www.icpac.net/capacity-development/" title="Capacity Development Services">Capacity Development</a></li>
+                        <li><a href="https://www.icpac.net/climate-change/" title="Climate Change Services">Climate Change</a></li>
+                        <li><a href="https://www.icpac.net/disaster-risk-management/" title="Disaster Risk Management Services">Disaster Risk Management</a></li>
+                        <li><a href="https://www.icpac.net/environmental-monitoring/" title="Environmental Monitoring Services">Environmental Monitoring</a></li>
+                        <li><a href="https://www.icpac.net/water-resources/" title="Water Resources Services">Water Resources</a></li>
                     </ul>
                 </div>
                 
                 <!-- PRODUCTS AND DATA section -->
                 <div class="column is-one-quarter">
-                    <h4 class="footer-heading">PRODUCTS AND DATA</h4>
+                    <h2 class="footer-heading is-size-5">PRODUCTS AND DATA</h2>
                     <ul>
-                        <li><a href="https://droughtwatch.icpac.net/mapviewer/">Drought Watch</a></li>
-                        <li><a href="http://197.254.1.10:8094/">Flood Watch</a></li>
-                        <li><a href="http://41.220.118.182:3000/">Pest Watch</a></li>
-                        <li><a href="https://agriculturehotspots.icpac.net/">Agriculture Watch</a></li>
-                        <li><a href="https://www.icpac.net/climate-monitoring/">Climate monitoring</a></li>
-                        <li><a href="https://www.icpac.net/fsnwg/">Food Security</a></li>
-                        <li><a href="https://www.icpac.net/data-center/">Our Data</a></li>
-                        <li><a href="https://www.icpac.net/open-data-sources/">Open Data</a></li>
+                        <li><a href="https://droughtwatch.icpac.net/mapviewer/" title="ICPAC Drought Watch Platform">Drought Watch</a></li>
+                        <li><a href="http://197.254.1.10:8094/" title="ICPAC Flood Watch Platform">Flood Watch</a></li>
+                        <li><a href="http://41.220.118.182:3000/" title="ICPAC Pest Watch Platform">Pest Watch</a></li>
+                        <li><a href="https://agriculturehotspots.icpac.net/" title="ICPAC Agriculture Watch Platform">Agriculture Watch</a></li>
+                        <li><a href="https://www.icpac.net/climate-monitoring/" title="ICPAC Climate Monitoring Resources">Climate Monitoring</a></li>
+                        <li><a href="https://www.icpac.net/fsnwg/" title="ICPAC Food Security Network Working Group">Food Security</a></li>
+                        <li><a href="https://www.icpac.net/data-center/" title="ICPAC Data Center">Our Data</a></li>
+                        <li><a href="https://www.icpac.net/open-data-sources/" title="ICPAC Open Data Sources">Open Data</a></li>
                     </ul>
                 </div>
                 
                 <!-- ORGANISATION section -->
                 <div class="column is-one-quarter">
-                    <h4 class="footer-heading">ORGANISATION</h4>
+                    <h2 class="footer-heading is-size-5">ORGANISATION</h2>
                     <ul>
-                        <li><a href="https://www.icpac.net/about-us/">About us</a></li>
-                        <li><a href="https://public.wmo.int/en">WMO Regional Climate Center</a></li>
-                        <li><a href="https://www.icpac.net/contact-us/">Contact Us</a></li>
-                        <li><a href="https://www.icpac.net/our-projects/">Our Projects</a></li>
+                        <li><a href="https://www.icpac.net/about-us/" title="About ICPAC">About Us</a></li>
+                        <li><a href="https://public.wmo.int/en" title="World Meteorological Organization">WMO Regional Climate Center</a></li>
+                        <li><a href="https://www.icpac.net/contact-us/" title="Contact ICPAC">Contact Us</a></li>
+                        <li><a href="https://www.icpac.net/our-projects/" title="ICPAC Projects">Our Projects</a></li>
                     </ul>
                     <div class="feedback-button" style="margin-top:1.5rem;">
-                        <a href="https://www.icpac.net/feedback/" class="button is-small is-outlined is-rounded">Give us feedback</a>
+                        <a href="https://www.icpac.net/feedback/" class="button is-small is-outlined is-rounded" title="Provide feedback to ICPAC">
+                            <span>Send Feedback</span>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -181,15 +183,16 @@
             <!-- Copyright and social media section -->
             <div class="columns">
                 <div class="column is-half">
-                    <p class="copyright">© ICPAC {% now "Y" %}</p>
+                    <p class="copyright">© ICPAC {% now "Y" %} - All Rights Reserved</p>
                 </div>
                 <div class="column is-half">
                     <div class="social-icons">
-                        <a href="https://www.facebook.com/ICPACigad/" class="social-icon"><i class="fab fa-facebook-f"></i></a>
-                        <a href="https://twitter.com/icpac_igad" class="social-icon"><i class="fab fa-youtube"></i></a>
-                        <a href="https://www.youtube.com/channel/UCoiL8Xk0_55BtXNBgEO4pRA?view_as=subscriber" class="social-icon"><i class="fab fa-linkedin-in"></i></a>
-                        <a href="https://github.com/icpac-igad" class="social-icon"><i class="fab fa-github"></i></a>
-                        <a href="https://podcasts.google.com/u/1/b/101015309335939692066/search/icpac" class="social-icon"><i class="fas fa-podcast"></i></a>
+                        <a href="https://www.facebook.com/ICPACigad/" class="social-icon" title="ICPAC on Facebook"><i class="fab fa-facebook-f" aria-hidden="true"></i><span class="sr-only">Facebook</span></a>
+                        <a href="https://twitter.com/icpac_igad" class="social-icon" title="ICPAC on Twitter"><i class="fab fa-twitter" aria-hidden="true"></i><span class="sr-only">Twitter</span></a>
+                        <a href="https://www.youtube.com/channel/UCoiL8Xk0_55BtXNBgEO4pRA?view_as=subscriber" class="social-icon" title="ICPAC on YouTube"><i class="fab fa-youtube" aria-hidden="true"></i><span class="sr-only">YouTube</span></a>
+                        <a href="https://www.linkedin.com/company/icpac/" class="social-icon" title="ICPAC on LinkedIn"><i class="fab fa-linkedin-in" aria-hidden="true"></i><span class="sr-only">LinkedIn</span></a>
+                        <a href="https://github.com/icpac-igad" class="social-icon" title="ICPAC on GitHub"><i class="fab fa-github" aria-hidden="true"></i><span class="sr-only">GitHub</span></a>
+                        <a href="https://podcasts.google.com/u/1/b/101015309335939692066/search/icpac" class="social-icon" title="ICPAC Podcasts"><i class="fas fa-podcast" aria-hidden="true"></i><span class="sr-only">Podcasts</span></a>
                     </div>
                 </div>
             </div>

--- a/geomanagerweb/templates/navbar.html
+++ b/geomanagerweb/templates/navbar.html
@@ -1,0 +1,261 @@
+{% load static wagtailsettings_tags wagtailimages_tags %}
+{% get_settings use_default_site=True %}
+
+<!-- Navbar implementation styled like the Drought Watch example -->
+<nav id="navbar" class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+  <div class="container is-fluid">
+    <div class="navbar-brand">
+      {% with settings.geomanager.geomanagersettings as gm %}
+        {% if gm.logo %}
+          <a href="/" class="logo">
+            {% image gm.logo original as logo_img %}
+            <img src="{{ logo_img.url }}" alt="{{ gm.site_name|default:'Brand Logo' }}" class="img-fluid">
+          </a>
+        {% else %}
+          <a href="/" class="logo">
+            <img src="{% static 'images/logo.png' %}" alt="Brand Logo" class="img-fluid">
+          </a>
+        {% endif %}
+      {% endwith %}
+
+      <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false"
+         data-target="mainNavbar">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </a>
+    </div>
+
+    {% if settings.geomanager.geomanagersettings.navigation %}
+      <div id="mainNavbar" class="navbar-menu">
+        <div class="navbar-start">
+          {% for menu_item_block in settings.geomanager.geomanagersettings.navigation %}
+            {% for menu_item in menu_item_block.value %}
+              {% if menu_item.page.url or menu_item.external_link %}
+                {% if menu_item.children %}
+                  <!-- Dropdown menu item -->
+                  <div class="navbar-item has-dropdown is-hoverable">
+                    <a class="navbar-link nav-main-item">
+                      {{ menu_item.label }}
+                    </a>
+                    <div class="navbar-dropdown">
+                      {% for child in menu_item.children %}
+                        <a class="navbar-item dropdown-item" href="{{ child.url }}">
+                          {{ child.label }}
+                        </a>
+                      {% endfor %}
+                    </div>
+                  </div>
+                {% else %}
+                  <!-- Regular menu item with drought watch styling -->
+                  {% if menu_item.value.page.url %}
+                    <a class="navbar-item nav-main-item"
+                       href="{{ menu_item.page.url }}">{{ menu_item.label }}
+                    </a>
+                  {% else %}
+                    <a class="navbar-item nav-main-item"
+                       href="{{ menu_item.external_link }}">{{ menu_item.label }}
+                    </a>
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</nav>
+
+<style>
+  /* Custom Navbar Styling based on Drought Watch */
+  .navbar {
+    background-color: #034930;
+    min-height: 4.5rem;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
+    padding: 0;
+  }
+  
+  /* Container fluid to bring logo closer to edge */
+  .container.is-fluid {
+    padding-left: 12px;
+    max-width: 100%;
+    display: flex;
+    align-items: center;
+  }
+  
+  /* Logo styling with increased size */
+  .logo {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0;
+    margin-right: 2rem;
+  }
+  
+  .logo img {
+    max-height: 45px; /* Increased from 3.5rem */
+    width: auto;
+    transition: all 0.3s ease;
+  }
+  
+  @media screen and (min-width: 1024px) {
+    .logo img {
+      max-height: 56px; /* Even larger on desktop */
+    }
+  }
+  
+  /* DROUGHT WATCH-style main navbar items */
+  .navbar-item.nav-main-item, 
+  .navbar-link.nav-main-item {
+    color: white !important;
+    font-weight: 600;
+    font-size: 1.1rem;
+    padding: 0.75rem 1.5rem;
+    background-color: transparent !important;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: background-color 0.3s;
+  }
+  
+  /* Special highlighting for active or hovered items */
+  .navbar-item.nav-main-item:hover, 
+  .navbar-link.nav-main-item:hover,
+  .navbar-item.nav-main-item.is-active,
+  .navbar-link.nav-main-item.is-active {
+    background-color: rgba(255, 255, 255, 0.15) !important;
+    color: white !important;
+  }
+  
+  /* Optional: special styling for MAPVIEWER button like in the example */
+  .navbar-item.nav-main-item.mapviewer {
+    background-color: #ffb800 !important;
+    color: #034930 !important;
+    border-radius: 2rem;
+    margin: 0 0.5rem;
+    padding: 0.65rem 1.25rem;
+    font-weight: 700;
+  }
+  
+  .navbar-item.nav-main-item.mapviewer:hover {
+    background-color: #ffc933 !important;
+  }
+  
+  .navbar-item {
+    color: white !important;
+    padding: 0.75rem 1rem;
+    background-color: transparent !important;
+  }
+  
+  /* Dropdown styling */
+  .navbar-dropdown {
+    background-color: #034930;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  }
+  
+  .navbar-dropdown .navbar-item {
+    padding: 0.75rem 1.5rem;
+    color: white !important;
+  }
+  
+  .navbar-dropdown .navbar-item:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+  }
+  
+  .navbar-link {
+    color: white !important;
+    font-weight: 600;
+    padding: 0.75rem 1.25rem;
+    background-color: transparent !important;
+  }
+  
+  .navbar-link::after {
+    border-color: white;
+  }
+  
+  /* Custom burger menu styling */
+  .navbar-burger {
+    color: white;
+    height: 4.5rem;
+    width: 4.5rem;
+  }
+  
+  .navbar-burger span {
+    background-color: white;
+    height: 2px;
+    width: 20px;
+  }
+  
+  .navbar-burger:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  
+  .navbar-menu {
+    background-color: #034930;
+    box-shadow: 0 8px 16px rgba(10, 10, 10, 0.1);
+    padding: 0;
+  }
+  
+  .navbar-menu.is-active {
+    display: block;
+  }
+  
+  /* Add padding to the body to account for taller fixed navbar */
+  body {
+    padding-top: 4.5rem;
+  }
+  
+  /* Media queries for responsive design */
+  @media screen and (max-width: 1023px) {
+    .navbar-menu {
+      padding: 0;
+    }
+    
+    .navbar-item.nav-main-item,
+    .navbar-link.nav-main-item {
+      text-align: center;
+      padding: 1rem;
+    }
+    
+    .navbar-dropdown .navbar-item {
+      padding-left: 2.5rem;
+      text-align: center;
+    }
+    
+    .container.is-fluid {
+      padding-left: 8px;
+    }
+    
+    .navbar-item.nav-main-item.mapviewer {
+      margin: 0.5rem 2rem;
+    }
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    // Get all "navbar-burger" elements
+    const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+    
+    // Add a click event on each of them
+    $navbarBurgers.forEach(el => {
+      el.addEventListener('click', () => {
+        // Get the target from the "data-target" attribute
+        const target = el.dataset.target;
+        const $target = document.getElementById(target);
+        
+        // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+        el.classList.toggle('is-active');
+        $target.classList.toggle('is-active');
+      });
+    });
+    
+    // Add mapviewer class to any menu item with "Mapviewer" or "Map" in the text
+    document.querySelectorAll('.navbar-item').forEach(item => {
+      if (item.textContent.trim().toLowerCase().includes('mapviewer') || 
+          item.textContent.trim().toLowerCase() === 'map') {
+        item.classList.add('mapviewer');
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
This PR updates the landing page to use a local navbar.html (placed in the same directory as base.html), replacing the previous reference to: https://github.com/icpac-igad/geomanager/blob/main/geomanager/templates/geomanager/navbar.html
A new navbar.html has been created, based on the original geomanager navbar, but customized to match the landing page theme.

Note: The geomapviewer is still referencing the original CSS from geomanager: https://github.com/icpac-igad/geomanager/blob/main/geomanager/static/geomanager/css/bulma-navbar.css

As a result, when opening the map viewer througn Explore button, the page still uses the default bulma-navbar.css styling.